### PR TITLE
Add playwright tests and fix WCAG violations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+PLAYWRIGHT_BASEURL="http://localhost:8080"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 /node_modules
 /coverage
 _site
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+.env

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
+	"files": {
+		"ignore": ["*/**/*.config.ts"]
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.1.0",
 			"license": "ISC",
 			"dependencies": {
-				"@lookupdaily/styles": "^1.1.1"
+				"@lookupdaily/styles": "2.0.0"
 			},
 			"devDependencies": {
 				"@11ty/eleventy": "^2.0.1",
@@ -2180,9 +2180,9 @@
 			}
 		},
 		"node_modules/@lookupdaily/styles": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@lookupdaily/styles/-/styles-1.1.1.tgz",
-			"integrity": "sha512-TnmEDbwcAq5L36Vwd8EFR86rrI8+qDISGXQoh5p5eiXwOA3WdCV5lZfWU5NSr6nNnog2Njf3H8t58Lo3fNX53Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@lookupdaily/styles/-/styles-2.0.0.tgz",
+			"integrity": "sha512-Fn+BLoi5yl+VTN4aNHla9VYgLwR5dd7Q1rhss5rBubOSeJcK9/3inRO3Xx9/IZKQQAS7Ydnqu2pN4VQFCYlljw==",
 			"license": "ISC"
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -8011,9 +8011,9 @@
 			}
 		},
 		"@lookupdaily/styles": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@lookupdaily/styles/-/styles-1.1.1.tgz",
-			"integrity": "sha512-TnmEDbwcAq5L36Vwd8EFR86rrI8+qDISGXQoh5p5eiXwOA3WdCV5lZfWU5NSr6nNnog2Njf3H8t58Lo3fNX53Q=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@lookupdaily/styles/-/styles-2.0.0.tgz",
+			"integrity": "sha512-Fn+BLoi5yl+VTN4aNHla9VYgLwR5dd7Q1rhss5rBubOSeJcK9/3inRO3Xx9/IZKQQAS7Ydnqu2pN4VQFCYlljw=="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,13 @@
 			},
 			"devDependencies": {
 				"@11ty/eleventy": "^2.0.1",
+				"@axe-core/playwright": "^4.10.0",
 				"@babel/core": "^7.24.7",
 				"@babel/preset-env": "^7.24.7",
 				"@biomejs/biome": "1.8.3",
 				"@playwright/test": "^1.47.2",
 				"@types/node": "^22.7.4",
+				"axe-core": "^4.10.0",
 				"babel-loader": "^9.1.3",
 				"css-loader": "^7.1.2",
 				"dotenv": "^16.4.5",
@@ -159,6 +161,19 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@axe-core/playwright": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.0.tgz",
+			"integrity": "sha512-kEr3JPEVUSnKIYp/egV2jvFj+chIjCjPp3K3zlpJMza/CB3TFw8UZNbI9agEC2uMz4YbgAOyzlbUy0QS+OofFA==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"axe-core": "~4.10.0"
+			},
+			"peerDependencies": {
+				"playwright-core": ">= 1.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -2697,6 +2712,16 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
 			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
 			"dev": true
+		},
+		"node_modules/axe-core": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+			"integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/babel-loader": {
 			"version": "9.1.3",
@@ -6610,6 +6635,15 @@
 				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
+		"@axe-core/playwright": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.0.tgz",
+			"integrity": "sha512-kEr3JPEVUSnKIYp/egV2jvFj+chIjCjPp3K3zlpJMza/CB3TFw8UZNbI9agEC2uMz4YbgAOyzlbUy0QS+OofFA==",
+			"dev": true,
+			"requires": {
+				"axe-core": "~4.10.0"
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
@@ -8384,6 +8418,12 @@
 			"version": "3.2.5",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
 			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+			"dev": true
+		},
+		"axe-core": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+			"integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
 			"dev": true
 		},
 		"babel-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,11 @@
 				"@babel/core": "^7.24.7",
 				"@babel/preset-env": "^7.24.7",
 				"@biomejs/biome": "1.8.3",
+				"@playwright/test": "^1.47.2",
+				"@types/node": "^22.7.4",
 				"babel-loader": "^9.1.3",
 				"css-loader": "^7.1.2",
+				"dotenv": "^16.4.5",
 				"mini-css-extract-plugin": "^2.9.1",
 				"sass": "^1.77.8",
 				"sass-loader": "^16.0.2",
@@ -2202,6 +2205,22 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@playwright/test": {
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz",
+			"integrity": "sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.47.2"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@sindresorhus/slugify": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
@@ -2264,12 +2283,13 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.14.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-			"integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+			"version": "22.7.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+			"integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~6.19.2"
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -3305,6 +3325,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.4.5",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/ee-first": {
@@ -5068,6 +5101,38 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/playwright": {
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz",
+			"integrity": "sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.47.2"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz",
+			"integrity": "sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/please-upgrade-node": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -6095,10 +6160,11 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.0",
@@ -7941,6 +8007,15 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@playwright/test": {
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz",
+			"integrity": "sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==",
+			"dev": true,
+			"requires": {
+				"playwright": "1.47.2"
+			}
+		},
 		"@sindresorhus/slugify": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
@@ -7988,12 +8063,12 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "20.14.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-			"integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+			"version": "22.7.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+			"integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
 			"dev": true,
 			"requires": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~6.19.2"
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -8735,6 +8810,12 @@
 				"domelementtype": "^2.2.0",
 				"domhandler": "^4.2.0"
 			}
+		},
+		"dotenv": {
+			"version": "16.4.5",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+			"dev": true
 		},
 		"ee-first": {
 			"version": "1.1.1",
@@ -9996,6 +10077,22 @@
 				"find-up": "^4.0.0"
 			}
 		},
+		"playwright": {
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz",
+			"integrity": "sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==",
+			"dev": true,
+			"requires": {
+				"fsevents": "2.3.2",
+				"playwright-core": "1.47.2"
+			}
+		},
+		"playwright-core": {
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz",
+			"integrity": "sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==",
+			"dev": true
+		},
 		"please-upgrade-node": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -10713,9 +10810,9 @@
 			"optional": true
 		},
 		"undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
 			"dev": true
 		},
 		"unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
 		"build": "npm run build:webpack && npm run build:eleventy",
 		"start": "npm run watch:webpack & npm run watch:eleventy",
 		"lint": "npx @biomejs/biome ci .",
-		"lint:fix": "npx @biomejs/biome check --write ."
+		"lint:fix": "npx @biomejs/biome check --write .",
+		"test:e2e": "npx playwright test",
+		"test:e2e:trace": "npx playwright test --project='chromium' --trace='on'",
+		"test:e2e:ui": "npx playwright test --project='chromium' --ui"
 	},
 	"keywords": [],
 	"author": "",
@@ -21,8 +24,11 @@
 		"@babel/core": "^7.24.7",
 		"@babel/preset-env": "^7.24.7",
 		"@biomejs/biome": "1.8.3",
+		"@playwright/test": "^1.47.2",
+		"@types/node": "^22.7.4",
 		"babel-loader": "^9.1.3",
 		"css-loader": "^7.1.2",
+		"dotenv": "^16.4.5",
 		"mini-css-extract-plugin": "^2.9.1",
 		"sass": "^1.77.8",
 		"sass-loader": "^16.0.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
 		"webpack-cli": "^5.1.4"
 	},
 	"dependencies": {
-		"@lookupdaily/styles": "^1.1.1"
+		"@lookupdaily/styles": "2.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
 	"license": "ISC",
 	"devDependencies": {
 		"@11ty/eleventy": "^2.0.1",
+		"@axe-core/playwright": "^4.10.0",
 		"@babel/core": "^7.24.7",
 		"@babel/preset-env": "^7.24.7",
 		"@biomejs/biome": "1.8.3",
 		"@playwright/test": "^1.47.2",
 		"@types/node": "^22.7.4",
+		"axe-core": "^4.10.0",
 		"babel-loader": "^9.1.3",
 		"css-loader": "^7.1.2",
 		"dotenv": "^16.4.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,80 @@
+import { defineConfig, devices } from "@playwright/test";
+import "dotenv/config";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+	testDir: "./tests",
+	/* Run tests in files in parallel */
+	fullyParallel: true,
+	/* Fail the build on CI if you accidentally left test.only in the source code. */
+	forbidOnly: !!process.env.CI,
+	/* Retry on CI only */
+	retries: process.env.CI ? 2 : 0,
+	/* Opt out of parallel tests on CI. */
+	workers: process.env.CI ? 1 : undefined,
+	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
+	reporter: "html",
+	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+	use: {
+		/* Base URL to use in actions like `await page.goto('/')`. */
+		baseURL: process.env.PLAYWRIGHT_BASEURL,
+
+		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+		trace: "on-first-retry",
+	},
+
+	/* Configure projects for major browsers */
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+
+		{
+			name: "firefox",
+			use: { ...devices["Desktop Firefox"] },
+		},
+
+		{
+			name: "webkit",
+			use: { ...devices["Desktop Safari"] },
+		},
+
+		/* Test against mobile viewports. */
+		// {
+		//   name: 'Mobile Chrome',
+		//   use: { ...devices['Pixel 5'] },
+		// },
+		// {
+		//   name: 'Mobile Safari',
+		//   use: { ...devices['iPhone 12'] },
+		// },
+
+		/* Test against branded browsers. */
+		// {
+		//   name: 'Microsoft Edge',
+		//   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+		// },
+		// {
+		//   name: 'Google Chrome',
+		//   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+		// },
+	],
+
+	/* Run your local dev server before starting the tests */
+	// webServer: {
+	//   command: "npm run start",
+	//   // url: "http://127.0.0.1:3000",
+	//   reuseExistingServer: !process.env.CI,
+	// },
+});

--- a/script/test
+++ b/script/test
@@ -6,8 +6,5 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-echo "==> Running tests..."
-npm run test
-
 echo "==> Checking code..."
 npm run lint

--- a/tests/a11y-violation.ts
+++ b/tests/a11y-violation.ts
@@ -1,0 +1,48 @@
+import AxeBuilder from "@axe-core/playwright";
+import type { Page } from "@playwright/test";
+import type axe from "axe-core";
+
+interface Ia11yViolation {
+	description: string;
+	impact: string;
+	instances: Ia11yViolationInstance[];
+	tags: string[];
+}
+
+interface Ia11yViolationInstance {
+	impact: string;
+	failureSummary: string;
+	target: string[];
+	html: string;
+}
+
+export class A11yViolation implements Ia11yViolation {
+	description: string;
+	impact: string;
+	tags: string[];
+	instances: Ia11yViolationInstance[];
+
+	constructor(result: axe.Result) {
+		this.description = result.description;
+		this.impact = result.impact ?? "";
+		this.tags = result.tags;
+		this.instances = result.nodes.map(
+			(node) =>
+				({
+					failureSummary: node.failureSummary,
+					html: node.html,
+					target: node.target,
+					impact: node.impact,
+				}) as Ia11yViolationInstance,
+		);
+	}
+
+	static async getAll(page: Page): Promise<A11yViolation[]> {
+		const accessibilityScanner = new AxeBuilder({
+			page,
+		}).withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"]);
+
+		const results = await accessibilityScanner.analyze();
+		return results.violations.map((violation) => new A11yViolation(violation));
+	}
+}

--- a/tests/accessibility-tests/about.spec.ts
+++ b/tests/accessibility-tests/about.spec.ts
@@ -1,0 +1,15 @@
+import { test } from "@playwright/test";
+import { AboutPage } from "../page-object-model/about-page";
+
+test.describe("Accessibility - Home page", () => {
+	let aboutPage: AboutPage;
+	test.beforeEach(({ page }) => {
+		aboutPage = new AboutPage(page);
+	});
+
+	test("should have no issues", async () => {
+		await aboutPage.goTo();
+		await aboutPage.expect.toBeOnPage();
+		await aboutPage.expect.toHaveNoAccessibilityIssues();
+	});
+});

--- a/tests/accessibility-tests/cv.spec.ts
+++ b/tests/accessibility-tests/cv.spec.ts
@@ -1,0 +1,15 @@
+import { test } from "@playwright/test";
+import { CvPage } from "../page-object-model/cv-page";
+
+test.describe("Accessibility - Home page", () => {
+	let cvPage: CvPage;
+	test.beforeEach(({ page }) => {
+		cvPage = new CvPage(page);
+	});
+
+	test("should have no issues", async () => {
+		await cvPage.goTo();
+		await cvPage.expect.toBeOnPage();
+		await cvPage.expect.toHaveNoAccessibilityIssues();
+	});
+});

--- a/tests/accessibility-tests/home.spec.ts
+++ b/tests/accessibility-tests/home.spec.ts
@@ -1,0 +1,15 @@
+import { test } from "@playwright/test";
+import { HomePage } from "../page-object-model/home-page";
+
+test.describe("Accessibility - Home page", () => {
+	let homePage: HomePage;
+	test.beforeEach(({ page }) => {
+		homePage = new HomePage(page);
+	});
+
+	test("should have no issues", async () => {
+		await homePage.goTo();
+		await homePage.expect.toBeOnPage();
+		await homePage.expect.toHaveNoAccessibilityIssues();
+	});
+});

--- a/tests/accessibility-tests/mobile.spec.ts
+++ b/tests/accessibility-tests/mobile.spec.ts
@@ -1,0 +1,19 @@
+import { test } from "@playwright/test";
+import { HomePage } from "../page-object-model/home-page";
+
+test.describe("Accessibility - Home page", () => {
+	let homePage: HomePage;
+	test.beforeEach(({ page }) => {
+		homePage = new HomePage(page);
+	});
+
+	test("should have no issues", async () => {
+		await homePage.goToMobile();
+		await homePage.expect.toBeOnPage();
+		await homePage.expect.toHaveNoAccessibilityIssues();
+
+		await homePage.clickOnMenu();
+		await homePage.expect.menuToBeVisible();
+		await homePage.expect.toHaveNoAccessibilityIssues();
+	});
+});

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -1,17 +1,24 @@
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
+import { CvPage } from "./page-object-model/cv-page";
+import { HomePage } from "./page-object-model/home-page";
 
-test("has title", async ({ page }) => {
-	await page.goto("/");
+test.describe("App", () => {
+	let homePage: HomePage;
+	test.beforeEach(({ page }) => {
+		homePage = new HomePage(page);
+	});
 
-	await expect(page).toHaveTitle(/Liz Daly/);
-});
+	test("go to homepage", async () => {
+		await homePage.goTo();
+		await homePage.expect.toBeOnPage();
+	});
 
-test("CV link", async ({ page }) => {
-	await page.goto("/");
+	test("has link to CV", async ({ page }) => {
+		const cvPage = new CvPage(page);
 
-	await page.getByRole("link", { name: "My CV" }).click();
+		await homePage.goTo();
+		await homePage.clickCvLink();
 
-	await expect(
-		page.getByRole("heading", { name: "Tech skills" }),
-	).toBeVisible();
+		await cvPage.expect.toBeOnPage();
+	});
 });

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@playwright/test";
+
+test("has title", async ({ page }) => {
+	await page.goto("/");
+
+	await expect(page).toHaveTitle(/Liz Daly/);
+});
+
+test("CV link", async ({ page }) => {
+	await page.goto("/");
+
+	await page.getByRole("link", { name: "My CV" }).click();
+
+	await expect(
+		page.getByRole("heading", { name: "Tech skills" }),
+	).toBeVisible();
+});

--- a/tests/page-object-model/about-page.ts
+++ b/tests/page-object-model/about-page.ts
@@ -1,0 +1,11 @@
+import type { Page } from "@playwright/test";
+import { BasePage, PageAssertions } from "./base-page";
+
+export class AboutPage extends BasePage {
+	readonly expect: PageAssertions;
+
+	constructor(page: Page) {
+		super(page, "/about", "Hello");
+		this.expect = new PageAssertions(this);
+	}
+}

--- a/tests/page-object-model/base-page.ts
+++ b/tests/page-object-model/base-page.ts
@@ -1,0 +1,28 @@
+import { type Locator, type Page, expect } from "@playwright/test";
+
+export class BasePage {
+	readonly url: string;
+	readonly headingLocator: Locator;
+	readonly page: Page;
+
+	constructor(page: Page, url: string, headingText: string) {
+		this.headingLocator = page.getByRole("heading", { name: headingText });
+		this.page = page;
+		this.url = url;
+	}
+
+	async goTo(): Promise<void> {
+		await this.page.goto(this.url);
+	}
+}
+
+export class PageAssertions {
+	readonly page: BasePage;
+	constructor(page: BasePage) {
+		this.page = page;
+	}
+
+	async toBeOnPage(): Promise<void> {
+		await expect(this.page.headingLocator).toBeVisible();
+	}
+}

--- a/tests/page-object-model/base-page.ts
+++ b/tests/page-object-model/base-page.ts
@@ -1,4 +1,5 @@
 import { type Locator, type Page, expect } from "@playwright/test";
+import { A11yViolation } from "../a11y-violation";
 
 export class BasePage {
 	readonly url: string;
@@ -24,5 +25,10 @@ export class PageAssertions {
 
 	async toBeOnPage(): Promise<void> {
 		await expect(this.page.headingLocator).toBeVisible();
+	}
+
+	async toHaveNoAccessibilityIssues(): Promise<void> {
+		const violations = await A11yViolation.getAll(this.page.page);
+		expect(violations).toEqual([]);
 	}
 }

--- a/tests/page-object-model/base-page.ts
+++ b/tests/page-object-model/base-page.ts
@@ -4,16 +4,33 @@ import { A11yViolation } from "../a11y-violation";
 export class BasePage {
 	readonly url: string;
 	readonly headingLocator: Locator;
+	readonly menuLocator: Locator;
+	readonly menuButtonLocator: Locator;
 	readonly page: Page;
 
 	constructor(page: Page, url: string, headingText: string) {
-		this.headingLocator = page.getByRole("heading", { name: headingText });
-		this.page = page;
 		this.url = url;
+		this.headingLocator = page.getByRole("heading", { name: headingText });
+		this.menuLocator = page.getByRole("navigation");
+		this.menuButtonLocator = page.getByRole("button", { name: "Menu" });
+		this.page = page;
 	}
 
 	async goTo(): Promise<void> {
 		await this.page.goto(this.url);
+	}
+
+	async goToMobile(): Promise<void> {
+		await this.page.setViewportSize({
+			width: 640,
+			height: 480,
+		});
+
+		await this.goTo();
+	}
+
+	async clickOnMenu(): Promise<void> {
+		await this.menuButtonLocator.click();
 	}
 }
 
@@ -25,6 +42,10 @@ export class PageAssertions {
 
 	async toBeOnPage(): Promise<void> {
 		await expect(this.page.headingLocator).toBeVisible();
+	}
+
+	async menuToBeVisible(): Promise<void> {
+		await expect(this.page.menuLocator).toBeVisible();
 	}
 
 	async toHaveNoAccessibilityIssues(): Promise<void> {

--- a/tests/page-object-model/cv-page.ts
+++ b/tests/page-object-model/cv-page.ts
@@ -1,0 +1,11 @@
+import type { Page } from "@playwright/test";
+import { BasePage, PageAssertions } from "./base-page";
+
+export class CvPage extends BasePage {
+	readonly expect: PageAssertions;
+
+	constructor(page: Page) {
+		super(page, "/cv", "Tech skills");
+		this.expect = new PageAssertions(this);
+	}
+}

--- a/tests/page-object-model/home-page.ts
+++ b/tests/page-object-model/home-page.ts
@@ -1,0 +1,17 @@
+import type { Locator, Page } from "@playwright/test";
+import { BasePage, PageAssertions } from "./base-page";
+
+export class HomePage extends BasePage {
+	readonly expect: PageAssertions;
+	readonly cvLinkLocator: Locator;
+
+	constructor(page: Page) {
+		super(page, "/", "Liz Daly");
+		this.expect = new PageAssertions(this);
+		this.cvLinkLocator = page.getByRole("link", { name: "My CV" });
+	}
+
+	async clickCvLink(): Promise<void> {
+		await this.cvLinkLocator.click();
+	}
+}

--- a/views/_includes/templates/menu.njk
+++ b/views/_includes/templates/menu.njk
@@ -2,7 +2,7 @@
 
 <span hidden id="menu-label">Main menu</span>
 <button class="ld-header__menu-button" id="ld-menu-button" aria-controls="ld-menu" aria-expanded="false" aria-haspopup="true"><span class="ld-header__menu-button-text">Menu</span></button>
-<nav class="ld-header-nav" id="ld-menu" aria-labelledy="menu-label">
+<nav class="ld-header-nav" id="ld-menu" aria-labelledby="menu-label">
   <ul class="ld-header-nav__list">
     <li class="ld-header-nav__item">
       <a class="ld-link ld-header-nav__link" href="/" {% if pageType == "home" %}data-state="active"{% endif %}><span class="nav__link__text">Home</span></a>

--- a/views/cv.njk
+++ b/views/cv.njk
@@ -13,35 +13,24 @@ description:  User-focused web developer with a background in marketing for the 
     <h2>Tech skills</h2>
     <p>I am a polyglot and quick learner of languages and frameworks. I believe that simple, well-documented and maintainable code is more important than language specialism.</p>
     <dl class="ld-descriptive-list">
-        <dt>
-          JavaScript
-        </dt>
-        <div class="ld-descriptive-list__gap">arrow_forward</div>
+        <dt>JavaScript</dt>
         <dd>
           ES6, TypeScript, Angular, React, Jest, Jasmine, Testing Library, Playwright
         </dd>
-        <dt>
-          CSS
-        </dt>
-        <div class="ld-descriptive-list__gap">arrow_forward</div>
+
+        <dt>CSS</dt>
         <dd>SCSS (Sass), CSS3, Bootstrap, Responsive designs</dd>
-        <dt>
-          HTML
-        </dt>
-        <div class="ld-descriptive-list__gap">arrow_forward</div>
+
+        <dt>HTML</dt>
         <dd>Semantic mark-up, accessibility following WAI-Aria Standards</dd>
-        <dt>
-          C#
-        </dt>
-        <div class="ld-descriptive-list__gap">arrow_forward</div>
+
+        <dt>C#</dt>
         <dd>ASP.NET Core, LINQ, Entity Framework Core, XUnit, Nunit, Fluent Assertions</dd>
-        <dt>
-          Ruby
-        </dt>
-        <div class="ld-descriptive-list__gap">arrow_forward</div>
+
+        <dt>Ruby</dt>
         <dd>Ruby on Rails, Sinatra, RSpec, Capybara</dd>
+
         <dt>Other</dt>
-        <div class="ld-descriptive-list__gap">arrow_forward</div>
         <dd>Git, Azure, Docker, Xcode, Swagger, SQL Server, Travis CI, CircleCI,
         pair programming, test driven development, peer reviews</dd>
     </dl>
@@ -51,40 +40,28 @@ description:  User-focused web developer with a background in marketing for the 
     <h2>Other skills</h2>
     {% include "./_includes/templates/links-open-in-new-tab.njk" %}
     <dl class="ld-descriptive-list">
-
-        <dt>
-          Collaborator
-        </dt>
-        <div class="ld-descriptive-list__gap">arrow_forward</div>
+        <dt>Collaborator</dt>
         <dd>
           I am at my happiest working on projects that require cross-team collaboration, particularly with user researchers, designers, product owners, web developers and business analysts. 
           I ask lots of questions and regularly present demos to clients and key stakeholders.
         </dd>
-        <dt>
-          User focused
-        </dt>
-        <div class="ld-descriptive-list__gap">arrow_forward</div>
+
+        <dt>User focused</dt>
         <dd>My communications experience has given me a passion for perfecting user experience, and championing inclusive design.</dd>
-        <dt>
-          Process driven
-        </dt>
-        <div class="ld-descriptive-list__gap">arrow_forward</div>
+        
+        <dt>Process driven</dt>
         <dd>
           Whilst learning to code at Makers I rediscovered my love for a good diagram. You can find 
           {{ link("some examples of my approach", "https://github.com/lookupdaily/chitter-challenge")}} 
           to developing solutions in my READMEs. I prefer to develop using TDD.
         </dd>
-        <dt>
-          Rapid learner
-        </dt>
-        <div class="ld-descriptive-list__gap">arrow_forward</div>
+
+        <dt>Rapid learner</dt>
         <dd>
           I have picked up the skills to learn new languages and technologies quickly. At Cognizant I have learnt Angular, .NET and Ionic for projects, and I have picked up new tooling regularly throughout my marketing career and architecture education. At dxw, I have honed my testing practices using Playwright, mutation testing and axe-core to improve my tests.
         </dd>
-      <dt>
-          Creative
-      </dt>
-      <div class="ld-descriptive-list__gap">arrow_forward</div>
+        
+      <dt>Creative</dt>
       <dd>
         I have a keen eye for design thanks to my background in architecture and design. I keep an open conversation with our UX teams to ensure consistent and usable design across our apps.
       </dd>


### PR DESCRIPTION
This adds playwright tests in order to run automated a11y tests using axe-core.

Have also made some changes to resolve two a11y violations:

- Fix a typo in an `aria-labelledby` attribute
- Remove an icon used at the top level of a descriptive list (as it had text content). This includes an update to [@lookupdaily/styles](https://github.com/lookupdaily/styles/releases/tag/v2.0.0)