### PR TITLE
Revisit links

### DIFF
--- a/views/_includes/layout.njk
+++ b/views/_includes/layout.njk
@@ -1,5 +1,3 @@
-{% from "./templates/link.njk" import link %}
-
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/views/_includes/templates/footer.njk
+++ b/views/_includes/templates/footer.njk
@@ -3,18 +3,18 @@
     <p class="ld-social-links">
       <span>Find me at @lookupdaily on </span>
       <span class="ld-social-links__item">
-        {{ link( "GitHub", "https://github.com/lookupdaily", "ld-link--hover-secondary") }}, 
+         <a class="ld-link ld-link--hover-secondary" href="https://github.com/lookupdaily">GitHub</a>, 
       </span>
       <span class="ld-social-links__item">
-        {{ link("Linkedin", "https://www.linkedin.com/in/lookupdaily", "ld-link--hover-secondary")}}, 
+        <a class="ld-link ld-link--hover-secondary" href="https://www.linkedin.com/in/lookupdaily">Linkedin</a>, 
       </span>
       <span class="ld-social-links__item">
-        {{ link("Instagram", "https://instagram.com/lookupdaily", "ld-link--hover-secondary")}}.
+        <a class="ld-link ld-link--hover-secondary" href="https://instagram.com/lookupdaily">Instagram</a>.
       </span>
     </p>
     <p class="ld-footer__credit">
       Made with 
-      {{ link("Eleventy", "https://www.11ty.dev/", "ld-link--hover-secondary")}}, 
+      <a class="ld-link ld-link--hover-secondary" href="https://www.11ty.dev/">Eleventy</a>, 
       &copy;Liz Daly 2022
     </p>
   </div>  

--- a/views/_includes/templates/link.njk
+++ b/views/_includes/templates/link.njk
@@ -1,3 +1,0 @@
-{% macro link(linkText, href, classes = "", opensInNewTab = true) %}
-  <a class="ld-link {{ classes }}" href="{{ href }}" {% if opensInNewTab %}rel="noreferrer noopener" target="blank"{% endif %}>
-    {{ linkText }}{% if opensInNewTab %}<span class="visually-hidden">(opens in a new tab)</span>{% endif %}</a>{% endmacro %}

--- a/views/_includes/templates/links-open-in-new-tab.njk
+++ b/views/_includes/templates/links-open-in-new-tab.njk
@@ -1,1 +1,0 @@
-<small class="ld-colour-grey">Links open in a new tab.</small>

--- a/views/_includes/templates/menu.njk
+++ b/views/_includes/templates/menu.njk
@@ -1,5 +1,3 @@
-{% from "./link.njk" import link %}
-
 <span hidden id="menu-label">Main menu</span>
 <button class="ld-header__menu-button" id="ld-menu-button" aria-controls="ld-menu" aria-expanded="false" aria-haspopup="true"><span class="ld-header__menu-button-text">Menu</span></button>
 <nav class="ld-header-nav" id="ld-menu" aria-labelledby="menu-label">
@@ -15,7 +13,7 @@
       <a class="ld-link ld-header-nav__link" href="/CV" {% if pageType == "cv" %}data-state="active"{% endif %}><span class="nav__link__text">CV</span></a>
     </li>
     <li class="ld-header-nav__item">
-      {{ link("GitHub", "https://github.com/lookupdaily", "ld-header-nav__link")}}
+      <a class="ld-link ld-header-nav__link" href="https://github.com/lookupdaily">GitHub</a>
     </li>
   </ul>
 </nav>

--- a/views/about.njk
+++ b/views/about.njk
@@ -5,31 +5,23 @@ title: Hello.
 pageType: about
 description: I'm Liz, a web developer based in London. I have recently taught myself to code and like to spend my time perfecting user experience and accessibility.
 ---
-{% from "./_includes/templates/link.njk" import link %}
-{% include "./_includes/templates/links-open-in-new-tab.njk" %}
-
 <p>
   My background is in the creative industry, as a marketeer for arts and design events. 
   Increasingly, our events were reliant on our digital platforms, which is where I was able to hone my interest in web development.
 </p>
 
 <p>
-  I have worked with brilliant web development teams to create and refine event websites such as 
-  {{ link("Clerkenwell Design Week", "https://www.clerkenwelldesignweek.com/") }}, 
-  100% Design and 
-  {{ link("Design Shanghai", "https://www.designshanghai.com/")}}—working across a range of content management systems. 
+  I have worked with brilliant web development teams to create and refine event websites such as <a href="https://www.clerkenwelldesignweek.com/" class="ld-link">Clerkenwell Design Week</a>, 100% Design and <a href="https://www.designshanghai.com/" class="ld-link">Design Shanghai</a>—working across a range of content management systems. 
   Now I am using some of my previous experience to build engaging, user friendly products myself.
 </p>
 
 <h2>Work</h2>
 
 <p>
-  After completing a software engineering course at Makers Academy, I spent some time working as a frontend developer at 
-  {{ link("Cognizant", "https://www.cognizant.com/us/en/services/digital-experience") }}. 
-  Here, I contributed to Network Rail's transformative 
-  {{ link("Intelligent Infrastructure", "https://www.networkrail.co.uk/running-the-railway/intelligent-infrastructure/") }} 
+  After completing a software engineering course at Makers Academy, I spent some time working as a frontend developer at <a href="https://www.cognizant.com/us/en/services/digital-experience" class="ld-link">Cognizant</a>. 
+  Here, I contributed to Network Rail's transformative <a href="https://www.networkrail.co.uk/running-the-railway/intelligent-infrastructure/" class="ld-link">Intelligent Infrastructure</a> 
   programme, which is using data to help railway maintenance become proactive rather than reactive. 
-  I am now working at {{ link("dxw", "https://www.dxw.com/") }}, a digital agency creating public services that improve lives.
+  I am now working at <a href="https://www.dxw.com/" class="ld-link">dxw</a>, a digital agency creating public services that improve lives.
 </p>
 
 <p>
@@ -40,7 +32,5 @@ description: I'm Liz, a web developer based in London. I have recently taught my
 <h2>Outside work</h2>
 
 <p>
-  When I'm not coding you can find me outside, with my hiking boots on or 
-  {{ link("looking up", "https://instagram.com/lookupdaily") }} 
-  at a great building.
+  When I'm not coding you can find me outside, with my hiking boots on or <a href="https://instagram.com/lookupdaily" class="ld-link">looking up</a> at a great building.
 </p>

--- a/views/cv.njk
+++ b/views/cv.njk
@@ -6,8 +6,6 @@ pageType: cv
 description:  User-focused web developer with a background in marketing for the arts and culture sector. I am interested in usability and accessibility and have strong experience in helping shape user requirements.
 ---
 
-{% from "./_includes/templates/link.njk" import link %}
-
 <div>
   <section class="ld-border-top--secondary">
     <h2>Tech skills</h2>
@@ -38,7 +36,7 @@ description:  User-focused web developer with a background in marketing for the 
 
   <section class="ld-border-top--secondary">
     <h2>Other skills</h2>
-    {% include "./_includes/templates/links-open-in-new-tab.njk" %}
+ 
     <dl class="ld-descriptive-list">
         <dt>Collaborator</dt>
         <dd>
@@ -52,7 +50,7 @@ description:  User-focused web developer with a background in marketing for the 
         <dt>Process driven</dt>
         <dd>
           Whilst learning to code at Makers I rediscovered my love for a good diagram. You can find 
-          {{ link("some examples of my approach", "https://github.com/lookupdaily/chitter-challenge")}} 
+          <a class="ld-link" href="https://github.com/lookupdaily/chitter-challenge">some examples of my approach</a> 
           to developing solutions in my READMEs. I prefer to develop using TDD.
         </dd>
 
@@ -69,23 +67,23 @@ description:  User-focused web developer with a background in marketing for the 
   </section>
   <section class="ld-border-top--secondary">
     <h2>Project experience</h2>
-    {% include "./_includes/templates/links-open-in-new-tab.njk" %}
+
     <div class="experience-item">
       <h3 class="experience-item__title">dxw - Developer</h3>
       <p class="experience-item__dates">January 2023-present</p>
       <p>Building public services that improve lives.</p>
       <ul class="ld-list">
         <li>I develop server side rendered applications in line with
-          {{ link("dxw's technology principles", "https://playbook.dxw.com/tech/development-and-technical-operations-team-principles/")}}
+          <a class="ld-link" href="https://playbook.dxw.com/tech/development-and-technical-operations-team-principles/">dxw's technology principles</a>
           which implement the GOV.UK design system and prioritise user needs, accessibility and maintainability.</li>
         <li>Delivering a new Application Programming Interface (API) to enable easier access to and analysis of
-          {{ link("UK Parliament's Members' Register of Financial Interests", "https://pds.blog.parliament.uk/2024/04/17/changing-the-way-members-register-their-interests/") }},
+          <a class="ld-link" href="https://pds.blog.parliament.uk/2024/04/17/changing-the-way-members-register-their-interests/">UK Parliament's Members' Register of Financial Interests</a>,
           as well as improved access for members of the public via the Parliament website.</li>
         <li>Launched the private beta of new internal product
-          {{ link("Find information about academies and trusts", "https://github.com/DFE-Digital/find-information-about-academies-and-trusts")}}
+          <a class="ld-link" href="https://github.com/DFE-Digital/find-information-about-academies-and-trusts">Find information about academies and trusts</a>
           for the Department of Education which helped relieve the team reliance on legacy technology.</li>
         <li>Helped build and write content for dxw's first iteration of our
-          {{ link("accessibility manual", "https://github.com/dxw/accessibility-manual")}}.</li>
+          <a class="ld-link" href="https://github.com/dxw/accessibility-manual">accessibility manual</a>.</li>
       </ul>
     </div>
 
@@ -94,7 +92,7 @@ description:  User-focused web developer with a background in marketing for the 
       <p class="experience-item__dates">September 2020-December 2023</p>
       <h4>Intelligent Infrastructure / Full-stack developer</h4>
       <p>Supporting the national roll-out of several key products for Network Rail as part of the
-        {{ link("Intelligent Infrastructure", "https://www.networkrail.co.uk/running-the-railway/intelligent-infrastructure/")}}
+        <a class="ld-link" href="https://www.networkrail.co.uk/running-the-railway/intelligent-infrastructure/">Intelligent Infrastructure</a>
         programme—a five-year transformation programme focused on providing maintenance teams the insight they need to predict and prevent faults before they cause delays.</p>
       <ul class="ld-list">
         <li>Deliver new product features in a small scrum team through the creation of fully tested UI components and APIs.</li>
@@ -110,34 +108,27 @@ description:  User-focused web developer with a background in marketing for the 
   </section>
   <section class="ld-border-top--secondary">
     <h2>Previous Experience</h2>
-    {% include "./_includes/templates/links-open-in-new-tab.njk" %}
+
     <div class="experience-item">
       <h3 class="experience-item__title">Waltham Forest Council - Project Lead, Communications Officer</h3>
       <p class="experience-item__dates">November 2017-December 2019 (with a travel break)</p>
       <p class="experience-item__description">
-        Oversaw the launch of an online culture hub for the London Borough of Waltham Forest. Managed digital content and promotion before and during Waltham Forest's year as the first 
-        {{ link(
-          "London Borough of Culture", 
-          "https://www.london.gov.uk/programmes-strategies/arts-and-culture/current-culture-projects/london-borough-culture"
-        ) }}
-        in 2019.</p>
+        Oversaw the launch of an online culture hub for the London Borough of Waltham Forest. Managed digital content and promotion before and during Waltham Forest's year as the first <a class="ld-link" href="https://www.london.gov.uk/programmes-strategies/arts-and-culture/current-culture-projects/london-borough-culture">London Borough of Culture</a> in 2019.</p>
     </div>
 
     <div class="experience-item">
       <h3 class="experience-item__title">New Designers - Marketing Manager</h3>
       <p class="experience-item__dates">May-July 2019</p>
       <p>Stepped in to deliver the final stages of the marketing campaign for 
-        {{ link("New Designers", "https://www.newdesigners.com/")}}
+        <a class="ld-link" href="https://www.newdesigners.com/">New Designers</a>
         2019 - the UK's #1 graduate design exhibition.</p>
     </div>
 
     <div class="experience-item">
       <h3 class="experience-item__title">Media 10 - Marketing Manager</h3>
       <p class="experience-item__dates">February 2013-October 2017 (Marketing Manager from 2016)</p>
-      <p>Produced tailored, data-driven campaigns for renowned trade events including 
-        {{ link("Clerkenwell Design Week", "https://www.clerkenwelldesignweek.com/")}}, 
-        100% Design, 
-        {{ link("Design Shanghai", "https://www.designshanghai.com/")}}.
+      <p>
+        Produced tailored, data-driven campaigns for renowned trade events including <a class="ld-link" href="https://www.clerkenwelldesignweek.com/">Clerkenwell Design Week</a>, 100% Design, <a class="ld-link" href="https://www.designshanghai.com/">Design Shanghai</a>.
         Worked with external and internal web development teams to manage new and existing websites for our growing portfolio, across a variety of web content management systems.</p>
     </div>
 

--- a/views/index.njk
+++ b/views/index.njk
@@ -13,7 +13,7 @@ description: Liz Daly is a front-end web developer interested in usability and i
     <p class="ld-text-subtitle">web developer.</p> 
   </header>
   <div>
-  <p class="ld-text-subtitle">A <a class="ld-link" href="https://makers.tech/" target="blank">Maker</a> and frontend developer with a background in marketing & communications for arts and design events. I have an interest in usability and accessibility, and am currently building public services that change lives at  <a class="ld-link" href="https://www.dxw.com/" target="blank">dxw</a>.</p>
+  <p class="ld-text-subtitle">A <a class="ld-link" href="https://makers.tech/">Maker</a> and frontend developer with a background in marketing & communications for arts and design events. I have an interest in usability and accessibility, and am currently building public services that change lives at  <a class="ld-link" href="https://www.dxw.com/">dxw</a>.</p>
 
   <span class="ld-text-subtitle ld-link arrow"><a href="/CV">My CV</a><span class="material-icons">arrow_forward</span></span>
   </div>


### PR DESCRIPTION
This removes a custom nujucks template for links in webpages, and brings back inline usage of the link `<a>` element.

I created this template to reduce overhead of open in new tab attributes and text in external links, but I wasn't entirely happy with it as spacing and alignment is sometimes a bit off in the final html document.

I've opted to remove links opening in new tabs, as this isn't essential and does against the WCAG recommendation for links. There are a few articles recommending against this deciding this for users too, such as these by [Chris Coyier](https://css-tricks.com/use-target_blank/) and [Vitaly Friedman](https://www.smashingmagazine.com/2008/07/should-links-open-in-new-windows/).