### PR TITLE
Update fonts

### DIFF
--- a/index.scss
+++ b/index.scss
@@ -20,7 +20,7 @@
   @include ld.margin-bottom("x-large");
 
   &__title {
-    margin-bottom: 0;
+    margin-bottom: 0.3125rem;
   }
 
   &__dates {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.1.0",
 			"license": "ISC",
 			"dependencies": {
-				"@lookupdaily/styles": "2.0.3"
+				"@lookupdaily/styles": "2.0.4"
 			},
 			"devDependencies": {
 				"@11ty/eleventy": "^2.0.1",
@@ -1860,9 +1860,9 @@
 			}
 		},
 		"node_modules/@lookupdaily/styles": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@lookupdaily/styles/-/styles-2.0.3.tgz",
-			"integrity": "sha512-/V90kD++qVsRdimhWyc67z5u8nKV6s9soTF2ykFwUGkiN22D5Q81JdLvMP4TuhJDUjDRERSmlYT+39PtrvAwHA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@lookupdaily/styles/-/styles-2.0.4.tgz",
+			"integrity": "sha512-DMj8CSrYkVN3RPPlsyKiRFpc1e1DatbpvdTT03R82AlqT8HW/e193P8Of/oLHMt5SJA8eUx3Xfy9egkly9p3dw==",
 			"license": "ISC"
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -7748,9 +7748,9 @@
 			}
 		},
 		"@lookupdaily/styles": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@lookupdaily/styles/-/styles-2.0.3.tgz",
-			"integrity": "sha512-/V90kD++qVsRdimhWyc67z5u8nKV6s9soTF2ykFwUGkiN22D5Q81JdLvMP4TuhJDUjDRERSmlYT+39PtrvAwHA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@lookupdaily/styles/-/styles-2.0.4.tgz",
+			"integrity": "sha512-DMj8CSrYkVN3RPPlsyKiRFpc1e1DatbpvdTT03R82AlqT8HW/e193P8Of/oLHMt5SJA8eUx3Xfy9egkly9p3dw=="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
 		"webpack-cli": "^5.1.4"
 	},
 	"dependencies": {
-		"@lookupdaily/styles": "2.0.3"
+		"@lookupdaily/styles": "2.0.4"
 	}
 }


### PR DESCRIPTION
This change brings in [font updates from @lookupdaily/styles](https://github.com/lookupdaily/styles/pull/87), which replace the previous use of google web fonts with websafe and system fonts.

This will speed up performance and file size for website page requests, and eliminates a page blocking resource.
Have left material icons font in place, but will consider the use of this too.